### PR TITLE
022/fixjest - Improvements For Developer Testing/Maintenance

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-env"]
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.vscode/
 coverage/
 .DS_Store
 jsconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ coverage/
 jsconfig.json
 node_modules/
 package-lock.json
-package.json
 *.geojson

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+	"liveServer.settings.proxy" : {
+		"enable": true,
+		"baseUri": "/busneighbor",
+		"proxyUri": "http://127.0.0.1:5500/"
+	}
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 * Fill a gap for responsive, multi-transit vehicle tracking
 
 # Test
-To run unit tests, configure by running `npm install --save-dev @babel/core @babel/preset-env babel-jest`. Then, run `npx jest --coverage`.
+To run unit tests, configure by running `npm install --save-dev jest`. Then, 
+run `npx --node-options='--experimental-vm-modules' jest --coverage`.
 
 # License
 TBD, but your first clue is that I don't mind the source being public :-)

--- a/__tests__/common/utilities.test.mjs
+++ b/__tests__/common/utilities.test.mjs
@@ -1,5 +1,5 @@
 import { includesAsWord, concatenateStrings, defineHiddenProperty,
-    iterableToString, objectOfKeys, safeAddToKeyedSet} from "../../common/utilities.js";
+    iterableToString, objectOfKeys} from "../../common/utilities.js";
 
 const TEXT_SOUGHT_WORD_EXPECTED_OUTCOME = [
     ["ABC", "ABC", true],

--- a/__tests__/service/location.test.mjs
+++ b/__tests__/service/location.test.mjs
@@ -1,3 +1,5 @@
+import {jest} from '@jest/globals';
+
 import { LatitudeLongitude } from "../../model/latitudeLongitude.js";
 
 import { getCurrentCoordinatesPromise, isApproachingMe, isLatitudeApproaching, isLongitudeApproaching,

--- a/__tests__/service/location.test.mjs
+++ b/__tests__/service/location.test.mjs
@@ -1,4 +1,4 @@
-import { LatitudeLongitude } from "/busneighbor/model/latitudeLongitude.js";
+import { LatitudeLongitude } from "../../model/latitudeLongitude.js";
 
 import { getCurrentCoordinatesPromise, isApproachingMe, isLatitudeApproaching, isLongitudeApproaching,
      perpendicularDegreeDistance, getExtremePositions, getMinimumEnclosingRectangle } from "../../service/location.js";

--- a/__tests__/service/septa_api_translation.test.mjs
+++ b/__tests__/service/septa_api_translation.test.mjs
@@ -1,14 +1,14 @@
+import { LatitudeLongitude } from "../../model/latitudeLongitude.js";
 import {  ALERT_SB_DISCONTINUED_ONE_ALERT,
      EARLY_BUS_12TH_BAINBRIDGE, MAGIC_VALUE_LOCATION
   } from "../stubs/septa_api_v2_samples.js";
 import { 
     createProcessedAlertV2, createProcessedLocationV2,
     routeAwarePerpendicularDistance } from "../../service/septa_api_translation.js";
-import { LatitudeLongitude } from "../../model/latitudeLongitude.js";
+
 import { ProcessedLocationV2 } from "../../model/processed_location.js";
 import { populateDistancesFromOrigin } from "../../service/septa_api_translation.js";
 import { perpendicularDegreeDistance } from "../../service/location.js";
-
 const EXPECTED_PROCESSED_LOCATION = { // No staleness; staleness is dynamic
   "routeIdentifier": "45",
   "vehicleLocation": { "latitude": 39.937599, "longitude": -75.163022 },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,0 @@
-module.exports = {
-  moduleNameMapper: {
-    '^/(.*)$': '<rootDir>/$1', // Map root paths to the project root
-  },
-  testMatch: ['**/*.test.mjs'],
-  testPathIgnorePatterns: ['/node_modules/', '/.vscode/'],
-  transform: { '^.+\\.(js|jsx|ts|tsx|mjs)$': 'babel-jest' }
-};

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,8 +1,7 @@
 // jest.config.mjs
 export default {
   testMatch: [
-    "**/__tests__/**/*.test.mjs", // Matches your current structure
-    "**/?(*.)+(spec|test).mjs"   // Optional: For other potential test file names
+    "**/__tests__/**/*.test.mjs"
   ],
   moduleNameMapper: {
     '^/busneighbor/(.*)$': '<rootDir>/$1'

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,10 @@
+// jest.config.mjs
+export default {
+  testMatch: [
+    "**/__tests__/**/*.test.mjs", // Matches your current structure
+    "**/?(*.)+(spec|test).mjs"   // Optional: For other potential test file names
+  ],
+  moduleNameMapper: {
+    '^/busneighbor/(.*)$': '<rootDir>/$1'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "busneighbor",
+  "type": "module",
+  "version": "1.0.0",
+  "description": "(New repo)",
+  "main": "script.js",
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jos-eph/busneighbor.git"
+  },
+  "keywords": [],
+  "author": "",
+  "bugs": {
+    "url": "https://github.com/jos-eph/busneighbor/issues"
+  },
+  "homepage": "https://github.com/jos-eph/busneighbor#readme",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}


### PR DESCRIPTION
* Persist `.vscode` directory so that we can preconfigure Live Server to match GitHub Pages' `/busneighbor` deploy
* Persist `package.json` to bake in jest test running instructions
* Update `jest.config.mjs` with `moduleNameMapper` to translate absolute paths in core files to relative paths without Babel
* Use ESM module syntax for Jest tests / `jest` object
* Fix broken tests
* Update readme with Jest runner instructions